### PR TITLE
Feat: NPC Pathing Early Implementation

### DIFF
--- a/misc/characters/vitoria.tres
+++ b/misc/characters/vitoria.tres
@@ -1,7 +1,8 @@
-[gd_resource type="Resource" script_class="Character" load_steps=8 format=3 uid="uid://0t7kidkdh5o3"]
+[gd_resource type="Resource" script_class="Character" load_steps=37 format=3 uid="uid://0t7kidkdh5o3"]
 
 [ext_resource type="Texture2D" uid="uid://b0mjha8y0k8dc" path="res://assets/images/entities/characters/vitorinha.tres" id="1_d0mor"]
 [ext_resource type="Script" uid="uid://c13w8ham8k8fc" path="res://misc/characters/Character.cs" id="1_g6utg"]
+[ext_resource type="Texture2D" uid="uid://c7ujvmy8ea8xr" path="res://assets/images/entities/characters/vitorinha.png" id="2_4vj45"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_7uy1x"]
 atlas = ExtResource("1_d0mor")
@@ -11,6 +12,54 @@ region = Rect2(256, 0, 64, 64)
 atlas = ExtResource("1_d0mor")
 region = Rect2(192, 0, 64, 64)
 
+[sub_resource type="AtlasTexture" id="AtlasTexture_622fg"]
+atlas = ExtResource("2_4vj45")
+region = Rect2(832, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_5cwbf"]
+atlas = ExtResource("2_4vj45")
+region = Rect2(896, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_ruek5"]
+atlas = ExtResource("2_4vj45")
+region = Rect2(832, 64, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_14iw8"]
+atlas = ExtResource("2_4vj45")
+region = Rect2(896, 64, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_ft8m4"]
+atlas = ExtResource("2_4vj45")
+region = Rect2(512, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_avvhg"]
+atlas = ExtResource("2_4vj45")
+region = Rect2(384, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_nyrbo"]
+atlas = ExtResource("2_4vj45")
+region = Rect2(512, 64, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_1pyng"]
+atlas = ExtResource("2_4vj45")
+region = Rect2(384, 64, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_7v76b"]
+atlas = ExtResource("2_4vj45")
+region = Rect2(704, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_25hw5"]
+atlas = ExtResource("2_4vj45")
+region = Rect2(640, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_nyj6b"]
+atlas = ExtResource("2_4vj45")
+region = Rect2(704, 64, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_ymj7u"]
+atlas = ExtResource("2_4vj45")
+region = Rect2(640, 64, 64, 64)
+
 [sub_resource type="AtlasTexture" id="AtlasTexture_k7k63"]
 atlas = ExtResource("1_d0mor")
 region = Rect2(256, 64, 64, 64)
@@ -18,6 +67,70 @@ region = Rect2(256, 64, 64, 64)
 [sub_resource type="AtlasTexture" id="AtlasTexture_yk738"]
 atlas = ExtResource("1_d0mor")
 region = Rect2(320, 64, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_yldvy"]
+atlas = ExtResource("2_4vj45")
+region = Rect2(128, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_rltk7"]
+atlas = ExtResource("2_4vj45")
+region = Rect2(64, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_1fmc3"]
+atlas = ExtResource("2_4vj45")
+region = Rect2(128, 64, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_ciu4b"]
+atlas = ExtResource("2_4vj45")
+region = Rect2(64, 64, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_7tcat"]
+atlas = ExtResource("2_4vj45")
+region = Rect2(576, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_lhfmn"]
+atlas = ExtResource("2_4vj45")
+region = Rect2(512, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_v7cqb"]
+atlas = ExtResource("2_4vj45")
+region = Rect2(576, 64, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_0p5jy"]
+atlas = ExtResource("2_4vj45")
+region = Rect2(512, 64, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_4rr3i"]
+atlas = ExtResource("2_4vj45")
+region = Rect2(768, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_h841n"]
+atlas = ExtResource("2_4vj45")
+region = Rect2(704, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_u75a5"]
+atlas = ExtResource("2_4vj45")
+region = Rect2(768, 64, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_et00b"]
+atlas = ExtResource("2_4vj45")
+region = Rect2(704, 64, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_kwfn4"]
+atlas = ExtResource("2_4vj45")
+region = Rect2(1024, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_r0ixr"]
+atlas = ExtResource("2_4vj45")
+region = Rect2(960, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_dcy2d"]
+atlas = ExtResource("2_4vj45")
+region = Rect2(1024, 64, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_fwqa6"]
+atlas = ExtResource("2_4vj45")
+region = Rect2(960, 64, 64, 64)
 
 [sub_resource type="SpriteFrames" id="SpriteFrames_kf5dk"]
 animations = [{
@@ -40,6 +153,72 @@ animations = [{
 }, {
 "frames": [{
 "duration": 1.0,
+"texture": SubResource("AtlasTexture_622fg")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_5cwbf")
+}],
+"loop": true,
+"name": &"idle_back",
+"speed": 5.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_ruek5")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_14iw8")
+}],
+"loop": true,
+"name": &"idle_back_selected",
+"speed": 5.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_ft8m4")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_avvhg")
+}],
+"loop": true,
+"name": &"idle_left",
+"speed": 5.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_nyrbo")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_1pyng")
+}],
+"loop": true,
+"name": &"idle_left_selected",
+"speed": 5.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_7v76b")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_25hw5")
+}],
+"loop": true,
+"name": &"idle_right",
+"speed": 5.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_nyj6b")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_ymj7u")
+}],
+"loop": true,
+"name": &"idle_right_selected",
+"speed": 5.0
+}, {
+"frames": [{
+"duration": 1.0,
 "texture": SubResource("AtlasTexture_k7k63")
 }, {
 "duration": 1.0,
@@ -54,6 +233,94 @@ animations = [{
 "loop": true,
 "name": &"idle_selected",
 "speed": 1.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_yldvy")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_rltk7")
+}],
+"loop": true,
+"name": &"walk_down",
+"speed": 5.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_1fmc3")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_ciu4b")
+}],
+"loop": true,
+"name": &"walk_down_selected",
+"speed": 0.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_7tcat")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_lhfmn")
+}],
+"loop": true,
+"name": &"walk_left",
+"speed": 5.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_v7cqb")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_0p5jy")
+}],
+"loop": true,
+"name": &"walk_left_selected",
+"speed": 5.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_4rr3i")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_h841n")
+}],
+"loop": true,
+"name": &"walk_right",
+"speed": 5.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_u75a5")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_et00b")
+}],
+"loop": true,
+"name": &"walk_right_selected",
+"speed": 5.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_kwfn4")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_r0ixr")
+}],
+"loop": true,
+"name": &"walk_up",
+"speed": 5.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_dcy2d")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_fwqa6")
+}],
+"loop": true,
+"name": &"walk_up_selected",
+"speed": 5.0
 }]
 
 [resource]

--- a/scenes/entities/NPC/NPC.tscn
+++ b/scenes/entities/NPC/NPC.tscn
@@ -1,8 +1,11 @@
-[gd_scene load_steps=7 format=3 uid="uid://f47qthi4c6ee"]
+[gd_scene load_steps=42 format=3 uid="uid://f47qthi4c6ee"]
 
-[ext_resource type="Script" path="res://scenes/entities/NPC/Npc.cs" id="1_n4d3i"]
-[ext_resource type="Texture2D" uid="uid://ca8g831ktm3nq" path="res://assets/images/entities/shadow.png" id="3_8e1h0"]
-[ext_resource type="Script" path="res://scenes/entities/NPC/NpcInteractableArea.cs" id="3_em6n5"]
+[ext_resource type="Script" uid="uid://bdhhfenspcgwc" path="res://scenes/entities/NPC/Npc.cs" id="1_n4d3i"]
+[ext_resource type="Resource" uid="uid://0t7kidkdh5o3" path="res://misc/characters/vitoria.tres" id="2_ruek5"]
+[ext_resource type="Texture2D" uid="uid://by186vm02hop" path="res://assets/images/entities/shadow.png" id="3_8e1h0"]
+[ext_resource type="Texture2D" uid="uid://b0mjha8y0k8dc" path="res://assets/images/entities/characters/vitorinha.tres" id="3_622fg"]
+[ext_resource type="Script" uid="uid://8cel10rdwnoq" path="res://scenes/entities/NPC/NpcInteractableArea.cs" id="3_em6n5"]
+[ext_resource type="Texture2D" uid="uid://c7ujvmy8ea8xr" path="res://assets/images/entities/characters/vitorinha.png" id="4_622fg"]
 
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_yh8lr"]
 radius = 19.0
@@ -12,17 +15,331 @@ height = 52.0
 radius = 9.0
 height = 34.0
 
-[sub_resource type="SpriteFrames" id="SpriteFrames_mlipu"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_7uy1x"]
+atlas = ExtResource("3_622fg")
+region = Rect2(256, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_xtwyr"]
+atlas = ExtResource("3_622fg")
+region = Rect2(192, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_622fg"]
+atlas = ExtResource("4_622fg")
+region = Rect2(832, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_5cwbf"]
+atlas = ExtResource("4_622fg")
+region = Rect2(896, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_ruek5"]
+atlas = ExtResource("4_622fg")
+region = Rect2(832, 64, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_14iw8"]
+atlas = ExtResource("4_622fg")
+region = Rect2(896, 64, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_ft8m4"]
+atlas = ExtResource("4_622fg")
+region = Rect2(512, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_avvhg"]
+atlas = ExtResource("4_622fg")
+region = Rect2(384, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_nyrbo"]
+atlas = ExtResource("4_622fg")
+region = Rect2(512, 64, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_1pyng"]
+atlas = ExtResource("4_622fg")
+region = Rect2(384, 64, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_7v76b"]
+atlas = ExtResource("4_622fg")
+region = Rect2(704, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_25hw5"]
+atlas = ExtResource("4_622fg")
+region = Rect2(640, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_nyj6b"]
+atlas = ExtResource("4_622fg")
+region = Rect2(704, 64, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_ymj7u"]
+atlas = ExtResource("4_622fg")
+region = Rect2(640, 64, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_k7k63"]
+atlas = ExtResource("3_622fg")
+region = Rect2(256, 64, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_yk738"]
+atlas = ExtResource("3_622fg")
+region = Rect2(320, 64, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_yldvy"]
+atlas = ExtResource("4_622fg")
+region = Rect2(128, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_rltk7"]
+atlas = ExtResource("4_622fg")
+region = Rect2(64, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_1fmc3"]
+atlas = ExtResource("4_622fg")
+region = Rect2(128, 64, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_ciu4b"]
+atlas = ExtResource("4_622fg")
+region = Rect2(64, 64, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_7tcat"]
+atlas = ExtResource("4_622fg")
+region = Rect2(576, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_lhfmn"]
+atlas = ExtResource("4_622fg")
+region = Rect2(512, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_v7cqb"]
+atlas = ExtResource("4_622fg")
+region = Rect2(576, 64, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_0p5jy"]
+atlas = ExtResource("4_622fg")
+region = Rect2(512, 64, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_4rr3i"]
+atlas = ExtResource("4_622fg")
+region = Rect2(768, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_h841n"]
+atlas = ExtResource("4_622fg")
+region = Rect2(704, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_u75a5"]
+atlas = ExtResource("4_622fg")
+region = Rect2(768, 64, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_et00b"]
+atlas = ExtResource("4_622fg")
+region = Rect2(704, 64, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_kwfn4"]
+atlas = ExtResource("4_622fg")
+region = Rect2(1024, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_r0ixr"]
+atlas = ExtResource("4_622fg")
+region = Rect2(960, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_dcy2d"]
+atlas = ExtResource("4_622fg")
+region = Rect2(1024, 64, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_fwqa6"]
+atlas = ExtResource("4_622fg")
+region = Rect2(960, 64, 64, 64)
+
+[sub_resource type="SpriteFrames" id="SpriteFrames_kf5dk"]
 animations = [{
-"frames": [],
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_7uy1x")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_xtwyr")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_7uy1x")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_xtwyr")
+}],
 "loop": true,
 "name": &"idle",
+"speed": 1.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_622fg")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_5cwbf")
+}],
+"loop": true,
+"name": &"idle_back",
+"speed": 5.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_ruek5")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_14iw8")
+}],
+"loop": true,
+"name": &"idle_back_selected",
+"speed": 5.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_ft8m4")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_avvhg")
+}],
+"loop": true,
+"name": &"idle_left",
+"speed": 5.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_nyrbo")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_1pyng")
+}],
+"loop": true,
+"name": &"idle_left_selected",
+"speed": 5.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_7v76b")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_25hw5")
+}],
+"loop": true,
+"name": &"idle_right",
+"speed": 5.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_nyj6b")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_ymj7u")
+}],
+"loop": true,
+"name": &"idle_right_selected",
+"speed": 5.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_k7k63")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_yk738")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_k7k63")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_yk738")
+}],
+"loop": true,
+"name": &"idle_selected",
+"speed": 1.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_yldvy")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_rltk7")
+}],
+"loop": true,
+"name": &"walk_down",
+"speed": 5.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_1fmc3")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_ciu4b")
+}],
+"loop": true,
+"name": &"walk_down_selected",
+"speed": 0.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_7tcat")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_lhfmn")
+}],
+"loop": true,
+"name": &"walk_left",
+"speed": 5.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_v7cqb")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_0p5jy")
+}],
+"loop": true,
+"name": &"walk_left_selected",
+"speed": 5.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_4rr3i")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_h841n")
+}],
+"loop": true,
+"name": &"walk_right",
+"speed": 5.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_u75a5")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_et00b")
+}],
+"loop": true,
+"name": &"walk_right_selected",
+"speed": 5.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_kwfn4")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_r0ixr")
+}],
+"loop": true,
+"name": &"walk_up",
+"speed": 5.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_dcy2d")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_fwqa6")
+}],
+"loop": true,
+"name": &"walk_up_selected",
 "speed": 5.0
 }]
 
 [node name="Npc" type="CharacterBody2D"]
 texture_filter = 1
+position = Vector2(0, 13.333334)
 script = ExtResource("1_n4d3i")
+CharacterInfo = ExtResource("2_ruek5")
+PatrolDistanceX = 50.0
 
 [node name="NpcInteractableArea" type="Area2D" parent="."]
 position = Vector2(0, 13)
@@ -48,5 +365,7 @@ scale = Vector2(0.055, 0.021)
 texture = ExtResource("3_8e1h0")
 
 [node name="Sprites" type="AnimatedSprite2D" parent="."]
-sprite_frames = SubResource("SpriteFrames_mlipu")
+sprite_frames = SubResource("SpriteFrames_kf5dk")
 animation = &"idle"
+frame_progress = 0.76556045
+offset = Vector2(-1, 0)

--- a/scenes/entities/NPC/Npc.cs
+++ b/scenes/entities/NPC/Npc.cs
@@ -5,74 +5,180 @@ using System;
 
 namespace Game.Entities
 {
-    [Tool]
-    public partial class Npc : CharacterBody2D
-    {
-        private Character _characterInfo;
-        private AnimatedSprite2D _animatedSprite;
-        private bool _hasSelect = false;
+	[Tool]
+	public partial class Npc : CharacterBody2D
+	{
+		private Character _characterInfo;
+		private AnimatedSprite2D _animatedSprite;
+		private bool _hasSelect = false;
+		public bool HasSelectState { get => _hasSelect; }
+		private Vector2 _startPosition;
+		private Vector2 _targetPosition;
+		private bool _goingToTarget = true;
+		private float _waitTimer = 0f;
+		private bool _isWaiting = false;
 
-        public bool HasSelectState { get => _hasSelect; }
+		[Export]
+		public Character CharacterInfo {
+			get => _characterInfo;
+			set
+			{
+				_animatedSprite ??= GetNodeOrNull<AnimatedSprite2D>("Sprites");
 
-        [Export]
-        public Character CharacterInfo {
-            get => _characterInfo;
-            set
-            {
-                if (value is Character character)
-                {
-                    _characterInfo = character;
-                    _animatedSprite ??= GetNode<AnimatedSprite2D>("Sprites");
-                    _animatedSprite.SpriteFrames = character.SpriteAnimations;
-                    _animatedSprite.Offset = character.SpritesOffset;
-                    _animatedSprite.Play();
-                    if (_animatedSprite.SpriteFrames is not null)
-                        _hasSelect = _animatedSprite.SpriteFrames.HasAnimation("idle_selected");
-                    else _hasSelect = false;
-                }
-                else
-                {
-                    _characterInfo = null;
-                    if (_animatedSprite is null) return;
-                    _animatedSprite.SpriteFrames = null;
-                    _animatedSprite.Offset = Vector2.Zero;
-                    _hasSelect = false;
-                }
-            }
-        }
+				if (_animatedSprite != null)
+				{
+					if (value is Character character)
+					{
+						_characterInfo = character;
+						_animatedSprite.SpriteFrames = character.SpriteAnimations;
+						_animatedSprite.Offset = character.SpritesOffset;
+						_animatedSprite.Play();
+						if (_animatedSprite.SpriteFrames is not null)
+							_hasSelect = _animatedSprite.SpriteFrames.HasAnimation("idle_selected");
+						else _hasSelect = false;
+					}
+					else
+					{
+						_characterInfo = null;
+						if (_animatedSprite is null) return;
+						_animatedSprite.SpriteFrames = null;
+						_animatedSprite.Offset = Vector2.Zero;
+						_hasSelect = false;
+					}
+				}else
+				{
+					_hasSelect = _characterInfo?.SpriteAnimations?.HasAnimation("idle_selected") ?? false;
+				}
+			}
+		}
 
-        [Export(PropertyHint.File, "*.json")]
-        public string DialoguePath { get; set; }
+		[Export(PropertyHint.File, "*.json")]
+		public string DialoguePath { get; set; }
 
-        [Export]
-        public Control InteractionUI { get; set; }
+		[Export]
+		public Control InteractionUI { get; set; }
 
-        public void ToggleHighlight(bool state)
-        {
-            var animationName = _animatedSprite.Animation.ToString();
-            var isCurrentAnimationHighlighted = animationName.EndsWith("selected");
-            var frame = _animatedSprite.Frame;
-            var frameProgress = _animatedSprite.FrameProgress;
-            if (state && !isCurrentAnimationHighlighted)
-            {
-                _animatedSprite.Play($"{animationName}_selected");
-                _animatedSprite.SetFrameAndProgress(frame, frameProgress);
-            }
-            else if (!state && isCurrentAnimationHighlighted)
-            {
-                _animatedSprite.Play(animationName.Replace("_selected", ""));
-                _animatedSprite.SetFrameAndProgress(frame, frameProgress);
-            }
-        }
+		[Export]
+		public float PatrolDistanceX { get; set; } = 0f;
 
-        public override void _Ready()
-        {
-            _animatedSprite = GetNode<AnimatedSprite2D>("Sprites");
-        }
+		[Export]
+		public float PatrolDistanceY { get; set; } = 0f;
 
-        // public override void _Process(double delta)
-        // {
-        //     _animatedSprite ??= GetNode<AnimatedSprite2D>("Sprites");
-        // }
-    }
+		[Export]
+		public float PatrolSpeed { get; set; } = 40f;
+
+		[Export]
+		public float PatrolWaitTime { get; set; } = 2f;
+
+		public bool IsInteracting { get; set; } = false;
+
+		public void ToggleHighlight(bool state)
+		{
+			var animationName = _animatedSprite.Animation.ToString();
+			var isCurrentAnimationHighlighted = animationName.EndsWith("selected");
+			var frame = _animatedSprite.Frame;
+			var frameProgress = _animatedSprite.FrameProgress;
+			if (state && !isCurrentAnimationHighlighted)
+			{
+				_animatedSprite.Play($"{animationName}_selected");
+				_animatedSprite.SetFrameAndProgress(frame, frameProgress);
+			}
+			else if (!state && isCurrentAnimationHighlighted)
+			{
+				_animatedSprite.Play(animationName.Replace("_selected", ""));
+				_animatedSprite.SetFrameAndProgress(frame, frameProgress);
+			}
+		}
+
+		public override void _PhysicsProcess(double delta)
+		{
+
+			if (IsInteracting)
+			{
+				Velocity = Vector2.Zero;
+				MoveAndSlide();
+				_animatedSprite.Stop();
+				_animatedSprite.Play("idle");
+				return; 
+			}
+			
+			if (PatrolDistanceX == 0 && PatrolDistanceY == 0)
+				return; 
+
+			if (_isWaiting)
+			{
+				_waitTimer -= (float)delta;
+				//henry peterson timer be like: "am i like, not delta or something?"
+				UpdateAnimation(Vector2.Zero);
+
+				if (_waitTimer <= 0f)
+					_isWaiting = false;
+
+				return;
+			}
+
+
+			Vector2 destination = _goingToTarget ? _targetPosition : _startPosition;
+			Vector2 direction = (destination - GlobalPosition).Normalized();
+
+			Velocity = direction * PatrolSpeed;
+			MoveAndSlide();
+
+			UpdateAnimation(direction);
+
+			if (GlobalPosition.DistanceTo(destination) < 2f)
+			{
+				_goingToTarget = !_goingToTarget; 
+				_isWaiting = true;
+				_waitTimer = PatrolWaitTime;
+				Velocity = Vector2.Zero;
+
+			}
+		}
+		
+		private void UpdateAnimation(Vector2 direction)
+		{
+			if (_animatedSprite == null) 
+				return;
+
+			string currentAnimation = _animatedSprite.Animation.ToString();
+			string selected = "";
+			
+			if(currentAnimation.EndsWith("_selected"))
+				selected = "_selected";
+
+			if (direction.Length() < 0.1f)
+			{
+				_animatedSprite.Play("idle" + selected);
+				return;
+			}
+
+			if (Mathf.Abs(direction.X) > Mathf.Abs(direction.Y))
+			{
+				if (direction.X > 0)
+					_animatedSprite.Play("walk_right" + selected);
+				else
+					_animatedSprite.Play("walk_left" + selected);
+			}
+			else
+			{
+				if (direction.Y > 0)
+					_animatedSprite.Play("walk_down" + selected);
+				else
+					_animatedSprite.Play("walk_up" + selected);
+			}
+		}
+
+		public override void _Ready()
+		{
+			_animatedSprite = GetNode<AnimatedSprite2D>("Sprites");
+			_startPosition = GlobalPosition;
+			_targetPosition = _startPosition + new Vector2(PatrolDistanceX, PatrolDistanceY);
+		}
+
+		// public override void _Process(double delta)
+		// {
+		//     _animatedSprite ??= GetNode<AnimatedSprite2D>("Sprites");
+		// }
+	}
 }

--- a/scenes/entities/NPC/NpcInteractableArea.cs
+++ b/scenes/entities/NPC/NpcInteractableArea.cs
@@ -26,6 +26,8 @@ namespace Game.Gameplay
             var npc = GetParent<Npc>();
             interacting = true;
             currentInteractor = interactor;
+
+            npc.IsInteracting = true;
             
             if (Interaction == 0 && npc.InteractionUI is NewDialogueUi ui
                 && interactor is Player player)
@@ -39,10 +41,13 @@ namespace Game.Gameplay
         }
         public override void StopInteraction(Node2D interactor)
         {
+            var npc = GetParent<Npc>();
             base.StopInteraction(interactor);
             _hasSelectedState = false;
             interacting = false;
             currentInteractor = null;
+
+            npc.IsInteracting = false;
         }
 
         private void OnDialogueFinished()


### PR DESCRIPTION
-- Features adicionadas --

- Adicionado mapeamento inicial de NPCs através do sistema de patrol, permitindo que o usuário selecione pelo próprio inspetor o movimento X e Y que será realizado pelo NPC na ida e volta, baseado na sua posição global como posição inicial, a velocidade em que o NPC andará durante a patrulha e o tempo de espera em idle até ele se virar e trocar de direção.

- Adicionado novos sprites walk e idle na spritesheet da NPC "vitorinha", que são utilizados durante a movimentação da NPC;

- Adicionado sistema de verificação de IsInteracting durante interação com NPC, forçando-o a parar seus movimentos e realizar a animação de idle.